### PR TITLE
Fix resending configs upon MQTT reconnects

### DIFF
--- a/include/mgos_homeassistant_api.h
+++ b/include/mgos_homeassistant_api.h
@@ -125,7 +125,7 @@ struct mgos_homeassistant_handler {
 extern "C" {
 #endif
 
-bool mgos_homeassistant_send_config(struct mgos_homeassistant *ha);
+bool mgos_homeassistant_send_config(struct mgos_homeassistant *ha, bool force);
 bool mgos_homeassistant_send_status(struct mgos_homeassistant *ha);
 bool mgos_homeassistant_add_handler(struct mgos_homeassistant *ha, ha_ev_handler ev_handler, void *user_data);
 bool mgos_homeassistant_call_handlers(struct mgos_homeassistant *ha, int ev, void *ev_data);

--- a/src/mgos_homeassistant.c
+++ b/src/mgos_homeassistant.c
@@ -39,7 +39,7 @@ static void mgos_homeassistant_mqtt_ev(struct mg_connection *nc, int ev, void *e
     case MG_EV_MQTT_CONNACK: {
       mgos_mqtt_pub(mgos_sys_config_get_device_id(), "online", 6, 0, true);
       if (user_data) {
-        mgos_homeassistant_send_config((struct mgos_homeassistant *) user_data);
+        mgos_homeassistant_send_config((struct mgos_homeassistant *) user_data, true);
         mgos_homeassistant_send_status((struct mgos_homeassistant *) user_data);
       }
       break;
@@ -150,7 +150,7 @@ bool mgos_homeassistant_fromjson(struct mgos_homeassistant *ha, const char *json
     SLIST_INSERT_HEAD(&ha->automations, a, entry);
   }
 
-  mgos_homeassistant_send_config(ha);
+  mgos_homeassistant_send_config(ha, false);
   if (name) free(name);
   return true;
 }

--- a/src/mgos_homeassistant_api.c
+++ b/src/mgos_homeassistant_api.c
@@ -285,7 +285,7 @@ static void mgos_homeassistant_mqtt_cb(struct mg_connection *nc, const char *top
   (void) nc;
 }
 
-bool mgos_homeassistant_send_config(struct mgos_homeassistant *ha) {
+bool mgos_homeassistant_send_config(struct mgos_homeassistant *ha, bool force) {
   struct mgos_homeassistant_object *o;
   if (!ha) return false;
   int done = 0, success = 0;
@@ -294,6 +294,7 @@ bool mgos_homeassistant_send_config(struct mgos_homeassistant *ha) {
 
   SLIST_FOREACH(o, &ha->objects, entry) {
     done++;
+    if (force) o->config_sent = false;
     if (mgos_homeassistant_object_send_config(o)) success++;
   }
   LOG((done == success) ? LL_DEBUG : LL_WARN, ("Sent %u configs (%u successfully) for node '%s'", done, success, ha->node_name));


### PR DESCRIPTION
All objects suppressed resending their configuration, having sent it
successfully via an earlier connection.