### PR TITLE
Config .provider clause handler infrastructure

### DIFF
--- a/include/mgos_homeassistant.h
+++ b/include/mgos_homeassistant.h
@@ -22,10 +22,13 @@
 extern "C" {
 #endif
 
+typedef bool (*ha_provider_cfg_handler)(struct mgos_homeassistant *ha, struct json_token val);
+
 struct mgos_homeassistant *mgos_homeassistant_get_global(void);
 bool mgos_homeassistant_fromfile(struct mgos_homeassistant *ha, const char *filename);
 bool mgos_homeassistant_fromjson(struct mgos_homeassistant *ha, const char *json);
 bool mgos_homeassistant_clear(struct mgos_homeassistant *ha);
+bool mgos_homeassistant_register_provider(const char *provider, ha_provider_cfg_handler cfg_handler, const char *mos_mod);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Add ha_provider_cfg_handler: cfg entry handler callback type.
Add mgos_homeassistant_register_provider(): API for adding providers.

mgos_homeassistant_fromjson():
  - Factor looping through .provider.foo config arrays out into
    mgos_homeassistant_fromjson_arr().
  - Factor handling built-in providers (barometer, bh1750, gpio, si7021) out
    into registering them in mgos_homeassistant_init().

(*) Also order #include directives as clang-format wants.